### PR TITLE
Add metric for avg broker latency for a record generated from producer to reach consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Kafka Monitor supports Apache Kafka 0.8 to 0.11:
 - Use branch 0.8.2.2 to work with Apache Kafka 0.8
 - Use branch 0.9.0.1 to work with Apache Kafka 0.9
 - Use branch 0.10.2.1 to work with Apache Kafka 0.10
-- Use master branch to work with Apache Kafka 0.11
+- Use branch 0.11.x to work with Apache Kafka 0.11
+- Use master branch to work with Apache Kafka 1.0
 
 
 ### Configuration Tips

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ allprojects {
     compile 'net.sourceforge.argparse4j:argparse4j:0.5.0'
     compile 'org.slf4j:slf4j-log4j12:1.7.6'
     compile 'org.apache.avro:avro:1.4.0'
-    compile 'org.apache.kafka:kafka_2.11:0.11.0.1'
-    compile 'org.apache.kafka:kafka-clients:0.11.0.1'
+    compile 'org.apache.kafka:kafka_2.11:1.0.1'
+    compile 'org.apache.kafka:kafka-clients:1.0.1'
     compile 'org.testng:testng:6.8.8'
     compile 'org.eclipse.jetty:jetty-server:8.1.19.v20160209'
     compile 'org.json:json:20140107'
@@ -69,5 +69,5 @@ allprojects {
 }
 
 task wrapper(type: Wrapper) {
-   gradleVersion = '2.11'
+   gradleVersion = '4.8.1'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ allprojects {
 
   checkstyle {
     configFile = new File(rootDir, "checkstyle/checkstyle.xml")
+    configProperties = [ "suppressionFile" : new File(rootDir, "checkstyle/suppressions.xml") ]
   }
 
   test.dependsOn('checkstyleMain', 'checkstyleTest')

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ allprojects {
     compile 'org.jolokia:jolokia-jvm:1.3.3'
     compile 'net.savantly:graphite-client:1.1.0-RELEASE'
     compile 'com.timgroup:java-statsd-client:3.0.1'
+    compile 'com.signalfx.public:signalfx-codahale:0.0.47'
 
     testCompile 'org.testng:testng:6.8.8'
   }

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -21,6 +21,10 @@
     <property name="header" value="/\*\*\nCopyright 2016 LinkedIn Corp. Licensed under the Apache License.*"/>
   </module>
 
+  <module name="SuppressionFilter">
+    <property name="file" value="${suppressionFile}"/>
+  </module>
+
   <module name="TreeWalker">
 
     <!-- code cleanup -->

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress checks="RegexpHeader" files="SignalFx*" />
+</suppressions>

--- a/config/kafka-monitor.properties
+++ b/config/kafka-monitor.properties
@@ -133,6 +133,16 @@
 #    ]
 #  }
 
+#  Example signalfx-service to report metrics
+# "signalfx-service": {
+#   "class.name": "com.linkedin.kmf.services.SignalFxMetricsReporterService",
+#   "report.interval.sec": 1,
+#   "report.metric.dimensions": {
+#   },
+#   "report.signalfx.url": "",
+#   "report.signalfx.token" : ""
+# }
+
 }
 
 

--- a/src/main/java/com/linkedin/kmf/services/ConsumeService.java
+++ b/src/main/java/com/linkedin/kmf/services/ConsumeService.java
@@ -9,21 +9,27 @@
  */
 package com.linkedin.kmf.services;
 
-import com.linkedin.kmf.common.DefaultTopicSchema;
-import com.linkedin.kmf.common.Utils;
-import com.linkedin.kmf.consumer.BaseConsumerRecord;
-import com.linkedin.kmf.consumer.KMBaseConsumer;
-import com.linkedin.kmf.consumer.NewConsumer;
-import com.linkedin.kmf.consumer.OldConsumer;
-import com.linkedin.kmf.services.configs.ConsumeServiceConfig;
+
+import static com.linkedin.kmf.common.Utils.ZK_CONNECTION_TIMEOUT_MS;
+import static com.linkedin.kmf.common.Utils.ZK_SESSION_TIMEOUT_MS;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.MetricName;
@@ -40,10 +46,23 @@ import org.apache.kafka.common.metrics.stats.Percentile;
 import org.apache.kafka.common.metrics.stats.Percentiles;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Total;
+import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.linkedin.kmf.common.DefaultTopicSchema;
+import com.linkedin.kmf.common.Utils;
+import com.linkedin.kmf.consumer.BaseConsumerRecord;
+import com.linkedin.kmf.consumer.KMBaseConsumer;
+import com.linkedin.kmf.consumer.NewConsumer;
+import com.linkedin.kmf.consumer.OldConsumer;
+import com.linkedin.kmf.services.configs.ConsumeServiceConfig;
+
+import kafka.cluster.Broker;
+import kafka.cluster.EndPoint;
+import kafka.utils.ZkUtils;
 
 public class ConsumeService implements Service {
   private static final Logger LOG = LoggerFactory.getLogger(ConsumeService.class);
@@ -60,26 +79,33 @@ public class ConsumeService implements Service {
   private final int _latencyPercentileGranularityMs;
   private final AtomicBoolean _running;
   private final int _latencySlaMs;
+  private final String _zkConnect;
+  private final String _topic;
+  private final ScheduledExecutorService _handlePartitionLeaderInfoExecutor;
+  private final Map<Integer, Broker> _partitionToBroker;
 
   public ConsumeService(Map<String, Object> props, String name) throws Exception {
     _name = name;
     Map consumerPropsOverride = props.containsKey(ConsumeServiceConfig.CONSUMER_PROPS_CONFIG)
       ? (Map) props.get(ConsumeServiceConfig.CONSUMER_PROPS_CONFIG) : new HashMap<>();
     ConsumeServiceConfig config = new ConsumeServiceConfig(props);
-    String topic = config.getString(ConsumeServiceConfig.TOPIC_CONFIG);
-    String zkConnect = config.getString(ConsumeServiceConfig.ZOOKEEPER_CONNECT_CONFIG);
+    _topic = config.getString(ConsumeServiceConfig.TOPIC_CONFIG);
+    _zkConnect = config.getString(ConsumeServiceConfig.ZOOKEEPER_CONNECT_CONFIG);
     String brokerList = config.getString(ConsumeServiceConfig.BOOTSTRAP_SERVERS_CONFIG);
     String consumerClassName = config.getString(ConsumeServiceConfig.CONSUMER_CLASS_CONFIG);
     _latencySlaMs = config.getInt(ConsumeServiceConfig.LATENCY_SLA_MS_CONFIG);
     _latencyPercentileMaxMs = config.getInt(ConsumeServiceConfig.LATENCY_PERCENTILE_MAX_MS_CONFIG);
     _latencyPercentileGranularityMs = config.getInt(ConsumeServiceConfig.LATENCY_PERCENTILE_GRANULARITY_MS_CONFIG);
     _running = new AtomicBoolean(false);
+    _partitionToBroker = new ConcurrentHashMap<>();
 
     for (String property: NONOVERRIDABLE_PROPERTIES) {
       if (consumerPropsOverride.containsKey(property)) {
         throw new ConfigException("Override must not contain " + property + " config.");
       }
     }
+
+    _handlePartitionLeaderInfoExecutor = Executors.newSingleThreadScheduledExecutor(new HandlePartitionLeaderInfoThreadFactory());
 
     Properties consumerProps = new Properties();
 
@@ -102,12 +128,12 @@ public class ConsumeService implements Service {
 
     // Assign config specified for ConsumeService.
     consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    consumerProps.put("zookeeper.connect", zkConnect);
+    consumerProps.put("zookeeper.connect", _zkConnect);
 
     // Assign config specified for consumer. This has the highest priority.
     consumerProps.putAll(consumerPropsOverride);
 
-    _consumer = (KMBaseConsumer) Class.forName(consumerClassName).getConstructor(String.class, Properties.class).newInstance(topic, consumerProps);
+    _consumer = (KMBaseConsumer) Class.forName(consumerClassName).getConstructor(String.class, Properties.class).newInstance(_topic, consumerProps);
 
     _thread = new Thread(new Runnable() {
       @Override
@@ -181,6 +207,16 @@ public class ConsumeService implements Service {
         nextIndexes.put(partition, index + 1);
         _sensors._recordsLost.record(index - nextIndex);
       }
+
+      Broker broker = _partitionToBroker.get(partition);
+      Collection<EndPoint> endPoints = scala.collection.JavaConversions.asJavaCollection(broker.endPoints());
+      for (EndPoint endpoint : endPoints) {
+        String brokerUrl = endpoint.host() + ":" + endpoint.port();
+        if (!_sensors._delayPerBroker.containsKey(brokerUrl)) {
+          _sensors.addBrokerSensors(brokerUrl);
+        }
+        _sensors._delayPerBroker.get(brokerUrl).record(currMs - prevMs);
+      }
     }
   }
 
@@ -188,6 +224,7 @@ public class ConsumeService implements Service {
   public synchronized void start() {
     if (_running.compareAndSet(false, true)) {
       _thread.start();
+      _handlePartitionLeaderInfoExecutor.scheduleWithFixedDelay(new PartitionLeaderInfoHandler(), 1000, 10000, TimeUnit.MILLISECONDS);
       LOG.info("{}/ConsumeService started", _name);
     }
   }
@@ -214,16 +251,49 @@ public class ConsumeService implements Service {
     return _running.get() && _thread.isAlive();
   }
 
+  /**
+   * This should be periodically run to check for addition or removal of brokers.
+   */
+  private class PartitionLeaderInfoHandler implements Runnable {
+
+    @Override
+    public void run() {
+      ZkUtils zkUtils = ZkUtils.apply(_zkConnect, ZK_SESSION_TIMEOUT_MS, ZK_CONNECTION_TIMEOUT_MS, JaasUtils.isZkSecurityEnabled());
+      scala.collection.mutable.ArrayBuffer<String> topicList = new scala.collection.mutable.ArrayBuffer<>();
+      topicList.$plus$eq(_topic);
+      scala.collection.Map<Object, scala.collection.Seq<Object>> partitionAssignments =
+          zkUtils.getPartitionAssignmentForTopics(topicList).apply(_topic);
+      scala.collection.Iterator<scala.Tuple2<Object, scala.collection.Seq<Object>>> it = partitionAssignments.iterator();
+      Set<Integer> partitionSet = new HashSet<>();
+      while (it.hasNext()) {
+        scala.Tuple2<Object, scala.collection.Seq<Object>> scalaTuple = it.next();
+        Integer partition = (Integer) scalaTuple._1();
+        partitionSet.add(partition);
+        scala.Option<Object> leaderOption = zkUtils.getLeaderForPartition(_topic, partition);
+        Broker broker = zkUtils.getBrokerInfo((Integer) leaderOption.get()).get();
+        _partitionToBroker.put(partition, broker);
+      }
+    }
+  }
+
   private class ConsumeMetrics {
     private final Sensor _bytesConsumed;
     private final Sensor _consumeError;
+    private final ConcurrentMap<String, Sensor> _delayPerBroker;
+    public final Metrics metrics;
     private final Sensor _recordsConsumed;
     private final Sensor _recordsDuplicated;
     private final Sensor _recordsLost;
     private final Sensor _recordsDelay;
     private final Sensor _recordsDelayed;
+    private final Map<String, String> _tags;
 
     public ConsumeMetrics(final Metrics metrics, final Map<String, String> tags) {
+      this.metrics = metrics;
+      this._tags = tags;
+
+      _delayPerBroker = new ConcurrentHashMap<>();
+
       _bytesConsumed = metrics.sensor("bytes-consumed");
       _bytesConsumed.add(new MetricName("bytes-consumed-rate", METRIC_GROUP_NAME, "The average number of bytes per second that are consumed", tags), new Rate());
 
@@ -280,6 +350,22 @@ public class ConsumeService implements Service {
       );
     }
 
+    void addBrokerSensors(String endpoint) {
+      if (_delayPerBroker.containsKey(endpoint)) {
+        return;
+      }
+      Sensor delayBrokerSensor = metrics.sensor("delay-broker-" + endpoint);
+      delayBrokerSensor.add(new MetricName("delay-ms-avg-broker-" + endpoint, METRIC_GROUP_NAME,
+          "The average latency of records from producer to consumer for broker", _tags),  new Avg());
+      _delayPerBroker.put(endpoint, delayBrokerSensor);
+    }
+  }
+
+  private class HandlePartitionLeaderInfoThreadFactory implements ThreadFactory {
+    @Override
+    public Thread newThread(Runnable r) {
+      return new Thread(r, _name + "-consume-service--partition-leader-handler");
+    }
   }
 
 }

--- a/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
+++ b/src/main/java/com/linkedin/kmf/services/MultiClusterTopicManagementService.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import kafka.admin.AdminUtils;
 import kafka.admin.BrokerMetadata;
 import kafka.admin.PreferredReplicaLeaderElectionCommand;
-import kafka.admin.RackAwareMode;
 import kafka.cluster.Broker;
 import kafka.common.TopicAndPartition;
 import kafka.server.ConfigType;
@@ -220,11 +219,15 @@ public class MultiClusterTopicManagementService implements Service {
     void maybeAddPartitions(int minPartitionNum) {
       ZkUtils zkUtils = ZkUtils.apply(_zkConnect, ZK_SESSION_TIMEOUT_MS, ZK_CONNECTION_TIMEOUT_MS, JaasUtils.isZkSecurityEnabled());
       try {
-        int partitionNum = getPartitionInfo(zkUtils, _topic).size();
+        scala.collection.Map<Object, scala.collection.Seq<Object>> existingAssignment = getPartitionAssignment(zkUtils, _topic);
+        int partitionNum = existingAssignment.size();
+
         if (partitionNum < minPartitionNum) {
           LOG.info("MultiClusterTopicManagementService will increase partition of the topic {} "
               + "in cluster {} from {} to {}.", _topic, _zkConnect, partitionNum, minPartitionNum);
-          AdminUtils.addPartitions(zkUtils, _topic, minPartitionNum, null, false, RackAwareMode.Enforced$.MODULE$);
+
+          scala.Option<scala.collection.Map<java.lang.Object, scala.collection.Seq<java.lang.Object>>> replicaAssignment = scala.Option.apply(null);
+          AdminUtils.addPartitions(zkUtils, _topic, existingAssignment, getAllBrokers(zkUtils), minPartitionNum, replicaAssignment, false);
         }
       } finally {
         zkUtils.close();
@@ -311,6 +314,23 @@ public class MultiClusterTopicManagementService implements Service {
       LOG.info("Current partition replica assignment " + currentAssignmentJson);
       LOG.info("New partition replica assignment " + newAssignmentJson);
       zkUtils.createPersistentPath(ZkUtils.ReassignPartitionsPath(), newAssignmentJson, zkUtils.DefaultAcls());
+    }
+
+    private static scala.collection.mutable.ArrayBuffer<BrokerMetadata> getAllBrokers(ZkUtils zkUtils) {
+      Collection<Broker> brokers = scala.collection.JavaConversions.asJavaCollection(zkUtils.getAllBrokersInCluster());
+      scala.collection.mutable.ArrayBuffer<BrokerMetadata> brokersMetadata = new scala.collection.mutable.ArrayBuffer<>(brokers.size());
+      for (Broker broker : brokers) {
+        brokersMetadata.$plus$eq(new BrokerMetadata(broker.id(), broker.rack()));
+      }
+      return brokersMetadata;
+    }
+
+    private static scala.collection.Map<Object, scala.collection.Seq<Object>> getPartitionAssignment(ZkUtils zkUtils, String topic) {
+      scala.collection.mutable.ArrayBuffer<String> topicList = new scala.collection.mutable.ArrayBuffer<>();
+      topicList.$plus$eq(topic);
+      scala.collection.Map<Object, scala.collection.Seq<Object>> partitionAssignment =
+          zkUtils.getPartitionAssignmentForTopics(topicList).apply(topic);
+      return partitionAssignment;
     }
 
     private static List<PartitionInfo> getPartitionInfo(ZkUtils zkUtils, String topic) {

--- a/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
+++ b/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
@@ -162,11 +162,9 @@ public class SignalFxMetricsReporterService implements Service {
     SettableDoubleGauge gauge = null;
 
     if (signalFxMetricName.contains("partition")) {
-      String partitionNumber = "" + signalFxMetricName.charAt(signalFxMetricName.length() - 1);
-      signalFxMetricName = signalFxMetricName.substring(0,  signalFxMetricName.length() - 2);
-      gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
-          .withMetricName(signalFxMetricName).metric();
-      _metricMetadata.forMetric(gauge).withDimension("partition", partitionNumber);
+      gauge = createPartitionMetric(signalFxMetricName);
+    } else if (signalFxMetricName.contains("delay-ms-avg-broker")) {
+      gauge = createBrokerMetric(signalFxMetricName);
     } else {
       gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
           .withMetricName(signalFxMetricName).metric();
@@ -177,7 +175,24 @@ public class SignalFxMetricsReporterService implements Service {
       _metricMetadata.forMetric(gauge).withDimension(entry.getKey(), entry.getValue());
     }
     _metricMetadata.forMetric(gauge).register(_metricRegistry);
+    return gauge;
+  }
 
+  private SettableDoubleGauge createBrokerMetric(String signalFxMetricName) {
+    String metricPart = "consume-service.delay-ms-avg-broker";
+    String brokerUrl = signalFxMetricName.split("broker-")[1];
+    SettableDoubleGauge gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
+        .withMetricName(metricPart).metric();
+    _metricMetadata.forMetric(gauge).withDimension("broker", brokerUrl);
+    return gauge;
+  }
+
+  private SettableDoubleGauge createPartitionMetric(String signalFxMetricName) {
+    String partitionNumber = "" + signalFxMetricName.charAt(signalFxMetricName.length() - 1);
+    signalFxMetricName = signalFxMetricName.substring(0,  signalFxMetricName.length() - 2);
+    SettableDoubleGauge gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
+        .withMetricName(signalFxMetricName).metric();
+    _metricMetadata.forMetric(gauge).withDimension("partition", partitionNumber);
     return gauge;
   }
 }

--- a/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
+++ b/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.linkedin.kmf.services;
+
+import static com.linkedin.kmf.common.Utils.getMBeanAttributeValues;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.MetricRegistry;
+import com.linkedin.kmf.common.MbeanAttributeValue;
+import com.linkedin.kmf.services.configs.SignalFxMetricsReporterServiceConfig;
+import com.signalfx.codahale.metrics.SettableDoubleGauge;
+import com.signalfx.codahale.reporter.MetricMetadata;
+import com.signalfx.codahale.reporter.SignalFxReporter;
+import com.signalfx.endpoint.SignalFxEndpoint;
+
+public class SignalFxMetricsReporterService implements Service {
+  private static final Logger LOG = LoggerFactory.getLogger(SignalFxMetricsReporterService.class);
+
+  private final String _name;
+  private final List<String> _metricNames;
+  private final int _reportIntervalSec;
+  private final ScheduledExecutorService _executor;
+  private final MetricRegistry _metricRegistry;
+  private final SignalFxReporter _signalfxReporter;
+  private final String _signalfxUrl;
+  private final String _signalfxToken;
+
+  private MetricMetadata _metricMetadata;
+  private Map<String, SettableDoubleGauge> _metricMap;
+  private Map<String, String> _dimensionsMap;
+
+  public SignalFxMetricsReporterService(Map<String, Object> props, String name) throws Exception {
+    SignalFxMetricsReporterServiceConfig config = new SignalFxMetricsReporterServiceConfig(props);
+
+    _name = name;
+    _metricNames = config.getList(SignalFxMetricsReporterServiceConfig.REPORT_METRICS_CONFIG);
+    _reportIntervalSec = config.getInt(SignalFxMetricsReporterServiceConfig.REPORT_INTERVAL_SEC_CONFIG);
+    _signalfxUrl = config.getString(SignalFxMetricsReporterServiceConfig.REPORT_SIGNALFX_URL);
+    _signalfxToken = config.getString(SignalFxMetricsReporterServiceConfig.SIGNALFX_TOKEN);
+
+    if (StringUtils.isEmpty(_signalfxToken)) {
+      throw new IllegalArgumentException("SignalFx token is not configured");
+    }
+
+    _executor = Executors.newSingleThreadScheduledExecutor();
+    _metricRegistry = new MetricRegistry();
+    _metricMap = new HashMap<String, SettableDoubleGauge>();
+    _dimensionsMap = new HashMap<String, String>();
+    if (props.containsKey(SignalFxMetricsReporterServiceConfig.SIGNALFX_METRIC_DIMENSION)) {
+      _dimensionsMap = (Map<String, String>) props.get(SignalFxMetricsReporterServiceConfig.SIGNALFX_METRIC_DIMENSION);
+    }
+
+    SignalFxReporter.Builder sfxReportBuilder = new SignalFxReporter.Builder(
+        _metricRegistry,
+        _signalfxToken
+    );
+    if (!StringUtils.isEmpty(_signalfxUrl)) {
+      sfxReportBuilder.setEndpoint(getSignalFxEndpoint(_signalfxUrl));
+    }
+    _signalfxReporter = sfxReportBuilder.build();
+
+    _metricMetadata = _signalfxReporter.getMetricMetadata();
+  }
+
+  @Override
+  public synchronized void start() {
+    _signalfxReporter.start(_reportIntervalSec, TimeUnit.SECONDS);
+    _executor.scheduleAtFixedRate(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          captureMetrics();
+        } catch (Exception e) {
+          LOG.error(_name + "/SignalFxMetricsReporterService failed to report metrics", e);
+        }
+      }
+    }, _reportIntervalSec, _reportIntervalSec, TimeUnit.SECONDS);
+    LOG.info("{}/SignalFxMetricsReporterService started", _name);
+  }
+
+  @Override
+  public synchronized void stop() {
+    _executor.shutdown();
+    _signalfxReporter.stop();
+    LOG.info("{}/SignalFxMetricsReporterService stopped", _name);
+  }
+
+  @Override
+  public boolean isRunning() {
+    return !_executor.isShutdown();
+  }
+
+  @Override
+  public void awaitShutdown() {
+    try {
+      _executor.awaitTermination(5, TimeUnit.MINUTES);
+    } catch (InterruptedException e) {
+      LOG.info("Thread interrupted when waiting for {}/SignalFxMetricsReporterService to shutdown", _name);
+    }
+    LOG.info("{}/SignalFxMetricsReporterService shutdown completed", _name);
+  }
+
+  private SignalFxEndpoint getSignalFxEndpoint(String urlStr) throws Exception {
+    URL url = new URL(urlStr);
+    return new SignalFxEndpoint(url.getProtocol(), url.getHost(), url.getPort());
+  }
+
+  private String generateSignalFxMetricName(String bean, String attribute) {
+    String service = bean.split(":")[1];
+    String serviceType = service.split(",")[1].split("=")[1];
+    return String.format("%s.%s", serviceType, attribute);
+  }
+
+  private void captureMetrics() {
+    for (String metricName : _metricNames) {
+      int index = metricName.lastIndexOf(':');
+      String mbeanExpr = metricName.substring(0, index);
+      String attributeExpr = metricName.substring(index + 1);
+
+      List<MbeanAttributeValue> attributeValues = getMBeanAttributeValues(mbeanExpr, attributeExpr);
+
+      for (final MbeanAttributeValue attributeValue : attributeValues) {
+        String metric = attributeValue.toString();
+        String key = metric.substring(0, metric.lastIndexOf("="));
+        String[] parts = key.split(",");
+        if (parts.length < 2) {
+          continue;
+        }
+        parts = parts[0].split("=");
+        if (parts.length < 2 || !parts[1].contains("cluster-monitor")) {
+          continue;
+        }
+        setMetricValue(attributeValue);
+      }
+    }
+  }
+
+  private void setMetricValue(MbeanAttributeValue attributeValue) {
+    String key = attributeValue.mbean() + attributeValue.attribute();
+    SettableDoubleGauge metric = _metricMap.get(key);
+    if (metric == null) {
+      metric = createMetric(attributeValue);
+      _metricMap.put(key, metric);
+    }
+    metric.setValue(attributeValue.value());
+  }
+
+  private SettableDoubleGauge createMetric(MbeanAttributeValue attributeValue) {
+    String signalFxMetricName = generateSignalFxMetricName(attributeValue.mbean(), attributeValue.attribute());
+    SettableDoubleGauge gauge = null;
+
+    if (signalFxMetricName.contains("partition")) {
+      String partitionNumber = "" + signalFxMetricName.charAt(signalFxMetricName.length() - 1);
+      signalFxMetricName = signalFxMetricName.substring(0,  signalFxMetricName.length() - 2);
+      gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
+          .withMetricName(signalFxMetricName).metric();
+      _metricMetadata.forMetric(gauge).withDimension("partition", partitionNumber);
+    } else {
+      gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
+          .withMetricName(signalFxMetricName).metric();
+    }
+    LOG.info("Creating metric : {}", signalFxMetricName);
+
+    for (Map.Entry<String, String> entry : _dimensionsMap.entrySet()) {
+      _metricMetadata.forMetric(gauge).withDimension(entry.getKey(), entry.getValue());
+    }
+    _metricMetadata.forMetric(gauge).register(_metricRegistry);
+
+    return gauge;
+  }
+}

--- a/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
+++ b/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
@@ -1,11 +1,5 @@
-/**
- * Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/*
+ * Copyright (C) 2018 SignalFx, Inc. All rights reserved.
  */
 package com.linkedin.kmf.services;
 

--- a/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package com.linkedin.kmf.services.configs;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+/**
+ * key/value pair used for configuring SignalFxMetricsReporterService
+ *
+ */
+public class SignalFxMetricsReporterServiceConfig extends AbstractConfig {
+  private static final ConfigDef CONFIG;
+
+  public static final String REPORT_METRICS_CONFIG = "report.metrics.list";
+  public static final String REPORT_METRICS_DOC = CommonServiceConfig.REPORT_METRICS_DOC;
+
+  public static final String REPORT_INTERVAL_SEC_CONFIG = CommonServiceConfig.REPORT_INTERVAL_SEC_CONFIG;
+  public static final String REPORT_INTERVAL_SEC_DOC = CommonServiceConfig.REPORT_INTERVAL_SEC_DOC;
+
+  public static final String REPORT_SIGNALFX_URL = "report.signalfx.url";
+  public static final String REPORT_SIGNALFX_URL_DOC = "The url of signalfx server which SignalFxMetricsReporterService will report the metrics values.";
+
+  public static final String SIGNALFX_METRIC_DIMENSION = "report.metric.dimensions";
+  public static final String SIGNALFX_METRIC_DIMENSION_DOC = "Dimensions added to each metric. Example: {\"key1:value1\", \"key2:value2\"} ";
+
+  public static final String SIGNALFX_TOKEN = "report.signalfx.token";
+  public static final String SIGNALFX_TOKEN_DOC = "SignalFx access token";
+
+  static {
+    CONFIG = new ConfigDef().define(REPORT_METRICS_CONFIG,
+                                    ConfigDef.Type.LIST,
+                                    Arrays.asList("kmf.services:*:*"),
+                                    ConfigDef.Importance.MEDIUM,
+                                    REPORT_METRICS_DOC)
+                             .define(REPORT_INTERVAL_SEC_CONFIG,
+                                    ConfigDef.Type.INT,
+                                    1,
+                                    ConfigDef.Importance.LOW,
+                                    REPORT_INTERVAL_SEC_DOC)
+                             .define(REPORT_SIGNALFX_URL,
+                                    ConfigDef.Type.STRING,
+                                    "",
+                                    ConfigDef.Importance.LOW,
+                                    REPORT_SIGNALFX_URL_DOC)
+                             .define(SIGNALFX_TOKEN,
+                                    ConfigDef.Type.STRING,
+                                    "",
+                                    ConfigDef.Importance.HIGH,
+                                    SIGNALFX_TOKEN_DOC);
+  }
+
+  public SignalFxMetricsReporterServiceConfig(Map<?, ?> props) {
+    super(CONFIG, props);
+  }
+}
+

--- a/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/SignalFxMetricsReporterServiceConfig.java
@@ -1,11 +1,5 @@
-/**
- * Copyright 2016 LinkedIn Corp. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
- * file except in compliance with the License. You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/*
+ * Copyright (C) 2018 SignalFx, Inc. All rights reserved.
  */
 package com.linkedin.kmf.services.configs;
 

--- a/src/test/java/com/linkedin/kmf/services/TopicManagementServiceTest.java
+++ b/src/test/java/com/linkedin/kmf/services/TopicManagementServiceTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 import kafka.cluster.Broker;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import com.linkedin.kmf.services.MultiClusterTopicManagementService.TopicManagementHelper;


### PR DESCRIPTION
1 - Add avg-delay metric per broker to determine latency for each broker from producer and consumer
2 - Each partition has one server which acts as the "leader" and zero or more servers which act as "followers". The leader handles all read and write requests for the partition while the followers passively replicate the leader
3 - PartitionLeaderInfoHandler runs periodically(every 10s) to update partition to broker configuration.
4 - Add consume-service.delay-ms-avg-broker metric to SignalFx with broker Url as a dimension. 