### PR TITLE
 Add metric for avg broker latency of a record generated from producer to reach consumer

### DIFF
--- a/src/main/java/com/linkedin/kmf/services/ConsumeService.java
+++ b/src/main/java/com/linkedin/kmf/services/ConsumeService.java
@@ -12,7 +12,13 @@ package com.linkedin.kmf.services;
 
 import static com.linkedin.kmf.common.Utils.ZK_CONNECTION_TIMEOUT_MS;
 import static com.linkedin.kmf.common.Utils.ZK_SESSION_TIMEOUT_MS;
-
+import com.linkedin.kmf.common.DefaultTopicSchema;
+import com.linkedin.kmf.common.Utils;
+import com.linkedin.kmf.consumer.BaseConsumerRecord;
+import com.linkedin.kmf.consumer.KMBaseConsumer;
+import com.linkedin.kmf.consumer.NewConsumer;
+import com.linkedin.kmf.consumer.OldConsumer;
+import com.linkedin.kmf.services.configs.ConsumeServiceConfig;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -27,7 +33,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.MetricName;
@@ -49,15 +54,6 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.linkedin.kmf.common.DefaultTopicSchema;
-import com.linkedin.kmf.common.Utils;
-import com.linkedin.kmf.consumer.BaseConsumerRecord;
-import com.linkedin.kmf.consumer.KMBaseConsumer;
-import com.linkedin.kmf.consumer.NewConsumer;
-import com.linkedin.kmf.consumer.OldConsumer;
-import com.linkedin.kmf.services.configs.ConsumeServiceConfig;
-
 import kafka.cluster.Broker;
 import kafka.cluster.EndPoint;
 import kafka.utils.ZkUtils;

--- a/src/main/java/com/linkedin/kmf/services/ConsumeService.java
+++ b/src/main/java/com/linkedin/kmf/services/ConsumeService.java
@@ -227,6 +227,7 @@ public class ConsumeService implements Service {
   public synchronized void stop() {
     if (_running.compareAndSet(true, false)) {
       try {
+        _handlePartitionLeaderInfoExecutor.shutdown();
         _consumer.close();
       } catch (Exception e) {
         LOG.warn(_name + "/ConsumeService while trying to close consumer.", e);

--- a/src/main/java/com/linkedin/kmf/services/ConsumeService.java
+++ b/src/main/java/com/linkedin/kmf/services/ConsumeService.java
@@ -9,21 +9,25 @@
  */
 package com.linkedin.kmf.services;
 
-import com.linkedin.kmf.common.DefaultTopicSchema;
-import com.linkedin.kmf.common.Utils;
-import com.linkedin.kmf.consumer.BaseConsumerRecord;
-import com.linkedin.kmf.consumer.KMBaseConsumer;
-import com.linkedin.kmf.consumer.NewConsumer;
-import com.linkedin.kmf.consumer.OldConsumer;
-import com.linkedin.kmf.services.configs.ConsumeServiceConfig;
+
+import static com.linkedin.kmf.common.Utils.ZK_CONNECTION_TIMEOUT_MS;
+import static com.linkedin.kmf.common.Utils.ZK_SESSION_TIMEOUT_MS;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.MetricName;
@@ -40,10 +44,23 @@ import org.apache.kafka.common.metrics.stats.Percentile;
 import org.apache.kafka.common.metrics.stats.Percentiles;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Total;
+import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.linkedin.kmf.common.DefaultTopicSchema;
+import com.linkedin.kmf.common.Utils;
+import com.linkedin.kmf.consumer.BaseConsumerRecord;
+import com.linkedin.kmf.consumer.KMBaseConsumer;
+import com.linkedin.kmf.consumer.NewConsumer;
+import com.linkedin.kmf.consumer.OldConsumer;
+import com.linkedin.kmf.services.configs.ConsumeServiceConfig;
+
+import kafka.cluster.Broker;
+import kafka.cluster.EndPoint;
+import kafka.utils.ZkUtils;
 
 public class ConsumeService implements Service {
   private static final Logger LOG = LoggerFactory.getLogger(ConsumeService.class);
@@ -60,26 +77,33 @@ public class ConsumeService implements Service {
   private final int _latencyPercentileGranularityMs;
   private final AtomicBoolean _running;
   private final int _latencySlaMs;
+  private final String _zkConnect;
+  private final String _topic;
+  private final ScheduledExecutorService _handlePartitionLeaderInfoExecutor;
+  private final Map<Integer, Broker> _partitionToBroker;
 
   public ConsumeService(Map<String, Object> props, String name) throws Exception {
     _name = name;
     Map consumerPropsOverride = props.containsKey(ConsumeServiceConfig.CONSUMER_PROPS_CONFIG)
       ? (Map) props.get(ConsumeServiceConfig.CONSUMER_PROPS_CONFIG) : new HashMap<>();
     ConsumeServiceConfig config = new ConsumeServiceConfig(props);
-    String topic = config.getString(ConsumeServiceConfig.TOPIC_CONFIG);
-    String zkConnect = config.getString(ConsumeServiceConfig.ZOOKEEPER_CONNECT_CONFIG);
+    _topic = config.getString(ConsumeServiceConfig.TOPIC_CONFIG);
+    _zkConnect = config.getString(ConsumeServiceConfig.ZOOKEEPER_CONNECT_CONFIG);
     String brokerList = config.getString(ConsumeServiceConfig.BOOTSTRAP_SERVERS_CONFIG);
     String consumerClassName = config.getString(ConsumeServiceConfig.CONSUMER_CLASS_CONFIG);
     _latencySlaMs = config.getInt(ConsumeServiceConfig.LATENCY_SLA_MS_CONFIG);
     _latencyPercentileMaxMs = config.getInt(ConsumeServiceConfig.LATENCY_PERCENTILE_MAX_MS_CONFIG);
     _latencyPercentileGranularityMs = config.getInt(ConsumeServiceConfig.LATENCY_PERCENTILE_GRANULARITY_MS_CONFIG);
     _running = new AtomicBoolean(false);
+    _partitionToBroker = new ConcurrentHashMap<>();
 
     for (String property: NONOVERRIDABLE_PROPERTIES) {
       if (consumerPropsOverride.containsKey(property)) {
         throw new ConfigException("Override must not contain " + property + " config.");
       }
     }
+
+    _handlePartitionLeaderInfoExecutor = Executors.newSingleThreadScheduledExecutor(new HandlePartitionLeaderInfoThreadFactory());
 
     Properties consumerProps = new Properties();
 
@@ -102,12 +126,12 @@ public class ConsumeService implements Service {
 
     // Assign config specified for ConsumeService.
     consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    consumerProps.put("zookeeper.connect", zkConnect);
+    consumerProps.put("zookeeper.connect", _zkConnect);
 
     // Assign config specified for consumer. This has the highest priority.
     consumerProps.putAll(consumerPropsOverride);
 
-    _consumer = (KMBaseConsumer) Class.forName(consumerClassName).getConstructor(String.class, Properties.class).newInstance(topic, consumerProps);
+    _consumer = (KMBaseConsumer) Class.forName(consumerClassName).getConstructor(String.class, Properties.class).newInstance(_topic, consumerProps);
 
     _thread = new Thread(new Runnable() {
       @Override
@@ -181,6 +205,16 @@ public class ConsumeService implements Service {
         nextIndexes.put(partition, index + 1);
         _sensors._recordsLost.record(index - nextIndex);
       }
+
+      Broker broker = _partitionToBroker.get(partition);
+      Collection<EndPoint> endPoints = scala.collection.JavaConversions.asJavaCollection(broker.endPoints());
+      for (EndPoint endpoint : endPoints) {
+        String brokerUrl = endpoint.host() + ":" + endpoint.port();
+        if (!_sensors._delayPerBroker.containsKey(brokerUrl)) {
+          _sensors.addBrokerSensors(brokerUrl);
+        }
+        _sensors._delayPerBroker.get(brokerUrl).record(currMs - prevMs);
+      }
     }
   }
 
@@ -188,6 +222,7 @@ public class ConsumeService implements Service {
   public synchronized void start() {
     if (_running.compareAndSet(false, true)) {
       _thread.start();
+      _handlePartitionLeaderInfoExecutor.scheduleWithFixedDelay(new PartitionLeaderInfoHandler(), 1000, 10000, TimeUnit.MILLISECONDS);
       LOG.info("{}/ConsumeService started", _name);
     }
   }
@@ -214,16 +249,47 @@ public class ConsumeService implements Service {
     return _running.get() && _thread.isAlive();
   }
 
+  /**
+   * This should be periodically run to check for addition or removal of brokers.
+   */
+  private class PartitionLeaderInfoHandler implements Runnable {
+
+    @Override
+    public void run() {
+      ZkUtils zkUtils = ZkUtils.apply(_zkConnect, ZK_SESSION_TIMEOUT_MS, ZK_CONNECTION_TIMEOUT_MS, JaasUtils.isZkSecurityEnabled());
+      scala.collection.mutable.ArrayBuffer<String> topicList = new scala.collection.mutable.ArrayBuffer<>();
+      topicList.$plus$eq(_topic);
+      scala.collection.Map<Object, scala.collection.Seq<Object>> partitionAssignments =
+          zkUtils.getPartitionAssignmentForTopics(topicList).apply(_topic);
+      scala.collection.Iterator<scala.Tuple2<Object, scala.collection.Seq<Object>>> it = partitionAssignments.iterator();
+      while (it.hasNext()) {
+        scala.Tuple2<Object, scala.collection.Seq<Object>> scalaTuple = it.next();
+        Integer partition = (Integer) scalaTuple._1();
+        scala.Option<Object> leaderOption = zkUtils.getLeaderForPartition(_topic, partition);
+        Broker broker = zkUtils.getBrokerInfo((Integer) leaderOption.get()).get();
+        _partitionToBroker.put(partition, broker);
+      }
+    }
+  }
+
   private class ConsumeMetrics {
     private final Sensor _bytesConsumed;
     private final Sensor _consumeError;
+    private final ConcurrentMap<String, Sensor> _delayPerBroker;
+    public final Metrics metrics;
     private final Sensor _recordsConsumed;
     private final Sensor _recordsDuplicated;
     private final Sensor _recordsLost;
     private final Sensor _recordsDelay;
     private final Sensor _recordsDelayed;
+    private final Map<String, String> _tags;
 
     public ConsumeMetrics(final Metrics metrics, final Map<String, String> tags) {
+      this.metrics = metrics;
+      this._tags = tags;
+
+      _delayPerBroker = new ConcurrentHashMap<>();
+
       _bytesConsumed = metrics.sensor("bytes-consumed");
       _bytesConsumed.add(new MetricName("bytes-consumed-rate", METRIC_GROUP_NAME, "The average number of bytes per second that are consumed", tags), new Rate());
 
@@ -280,6 +346,22 @@ public class ConsumeService implements Service {
       );
     }
 
+    void addBrokerSensors(String endpoint) {
+      if (_delayPerBroker.containsKey(endpoint)) {
+        return;
+      }
+      Sensor delayBrokerSensor = metrics.sensor("delay-broker-" + endpoint);
+      delayBrokerSensor.add(new MetricName("delay-ms-avg-broker-" + endpoint, METRIC_GROUP_NAME,
+          "The average latency of records from producer to consumer for broker", _tags),  new Avg());
+      _delayPerBroker.put(endpoint, delayBrokerSensor);
+    }
+  }
+
+  private class HandlePartitionLeaderInfoThreadFactory implements ThreadFactory {
+    @Override
+    public Thread newThread(Runnable r) {
+      return new Thread(r, _name + "-consume-service--partition-leader-handler");
+    }
   }
 
 }

--- a/src/main/java/com/linkedin/kmf/services/ConsumeService.java
+++ b/src/main/java/com/linkedin/kmf/services/ConsumeService.java
@@ -360,8 +360,9 @@ public class ConsumeService implements Service {
   private class HandlePartitionLeaderInfoThreadFactory implements ThreadFactory {
     @Override
     public Thread newThread(Runnable r) {
-      return new Thread(r, _name + "-consume-service--partition-leader-handler");
+      return new Thread(r, _name + "-consume-service-partition-leader-handler");
     }
   }
 
 }
+

--- a/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
+++ b/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
@@ -162,11 +162,9 @@ public class SignalFxMetricsReporterService implements Service {
     SettableDoubleGauge gauge = null;
 
     if (signalFxMetricName.contains("partition")) {
-      String partitionNumber = "" + signalFxMetricName.charAt(signalFxMetricName.length() - 1);
-      signalFxMetricName = signalFxMetricName.substring(0,  signalFxMetricName.length() - 2);
-      gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
-          .withMetricName(signalFxMetricName).metric();
-      _metricMetadata.forMetric(gauge).withDimension("partition", partitionNumber);
+      gauge = createPartitionMetric(signalFxMetricName);
+    } else if (signalFxMetricName.contains("delay-ms-avg-broker")) {
+      gauge = createBrokerMetric(signalFxMetricName);
     } else {
       gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
           .withMetricName(signalFxMetricName).metric();
@@ -177,7 +175,24 @@ public class SignalFxMetricsReporterService implements Service {
       _metricMetadata.forMetric(gauge).withDimension(entry.getKey(), entry.getValue());
     }
     _metricMetadata.forMetric(gauge).register(_metricRegistry);
+    return gauge;
+  }
 
+  private SettableDoubleGauge createBrokerMetric(String signalFxMetricName) {
+    String metricPart = "consume-service.delay-ms-avg-broker";
+    String brokerUrl = signalFxMetricName.split("broker-")[1];
+    SettableDoubleGauge gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
+        .withMetricName(metricPart).metric();
+    _metricMetadata.forMetric(gauge).withDimension("broker", brokerUrl);
+    return gauge;
+  }
+
+  private SettableDoubleGauge createPartitionMetric(String signalFxMetricName) {
+    String partitionNumber = "" + signalFxMetricName.charAt(signalFxMetricName.length() - 1);
+    signalFxMetricName = signalFxMetricName.substring(0,  signalFxMetricName.length() - 2);
+    SettableDoubleGauge gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
+        .withMetricName(signalFxMetricName).metric();
+    _metricMetadata.forMetric(gauge).withDimension("partition", partitionNumber);
     return gauge;
   }
 }

--- a/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
+++ b/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
@@ -188,8 +188,9 @@ public class SignalFxMetricsReporterService implements Service {
   }
 
   private SettableDoubleGauge createPartitionMetric(String signalFxMetricName) {
-    String partitionNumber = "" + signalFxMetricName.charAt(signalFxMetricName.length() - 1);
-    signalFxMetricName = signalFxMetricName.substring(0,  signalFxMetricName.length() - 2);
+    int divider = signalFxMetricName.lastIndexOf('-');
+    String partitionNumber = signalFxMetricName.substring(divider + 1);
+    signalFxMetricName = signalFxMetricName.substring(0,  divider);
     SettableDoubleGauge gauge = _metricMetadata.forMetric(new SettableDoubleGauge())
         .withMetricName(signalFxMetricName).metric();
     _metricMetadata.forMetric(gauge).withDimension("partition", partitionNumber);

--- a/src/main/java/com/linkedin/kmf/services/configs/ConsumeServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/ConsumeServiceConfig.java
@@ -9,10 +9,12 @@
  */
 package com.linkedin.kmf.services.configs;
 
-import com.linkedin.kmf.consumer.NewConsumer;
 import java.util.Map;
+
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
+
+import com.linkedin.kmf.consumer.NewConsumer;
 
 public class ConsumeServiceConfig extends AbstractConfig {
 
@@ -46,6 +48,9 @@ public class ConsumeServiceConfig extends AbstractConfig {
   public static final String LATENCY_SLA_MS_DOC = "The maximum latency of message delivery under SLA. Consume availability is measured "
                                                   + "as the fraction of messages that are either lost or whose delivery latency exceeds this value";
 
+  public static final String PARTITION_TO_LEADER_REFRESH_INTERVAL_MS_CONFIG = "consume.partitionToLeader.refresh.interval.ms";
+  public static final String PARTITION_TO_LEADER_REFRESH_INTERVAL_MS_DOC = "The interval in ms to find partition-leader mapping";
+
   static {
     CONFIG = new ConfigDef().define(ZOOKEEPER_CONNECT_CONFIG,
                                     ConfigDef.Type.STRING,
@@ -78,7 +83,12 @@ public class ConsumeServiceConfig extends AbstractConfig {
                                     ConfigDef.Type.INT,
                                     20000,
                                     ConfigDef.Importance.MEDIUM,
-                                    LATENCY_SLA_MS_DOC);
+                                    LATENCY_SLA_MS_DOC)
+                            .define(PARTITION_TO_LEADER_REFRESH_INTERVAL_MS_CONFIG,
+                                ConfigDef.Type.INT,
+                                10000,
+                                ConfigDef.Importance.MEDIUM,
+                                PARTITION_TO_LEADER_REFRESH_INTERVAL_MS_DOC);
 
   }
 

--- a/src/main/java/com/linkedin/kmf/services/configs/ConsumeServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/ConsumeServiceConfig.java
@@ -9,12 +9,10 @@
  */
 package com.linkedin.kmf.services.configs;
 
+import com.linkedin.kmf.consumer.NewConsumer;
 import java.util.Map;
-
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-
-import com.linkedin.kmf.consumer.NewConsumer;
 
 public class ConsumeServiceConfig extends AbstractConfig {
 


### PR DESCRIPTION


  1 - Add avg-delay metric per broker to determine latency for each broker from producer and consumer
  2 - Each partition has one server which acts as the "leader" and zero or more servers which act as "followers". The leader handles all read and write requests for the partition while the followers passively replicate the leader
  3 - PartitionLeaderInfoHandler runs periodically(every 10s) to update partition to broker configuration.