### PR TITLE
Add metric for avg broker latency of a record generated from producer to reach consumer for kafka version 0.9.0.1

### DIFF
--- a/src/main/java/com/linkedin/kmf/services/ConsumeService.java
+++ b/src/main/java/com/linkedin/kmf/services/ConsumeService.java
@@ -9,6 +9,8 @@
  */
 package com.linkedin.kmf.services;
 
+import static com.linkedin.kmf.common.Utils.ZK_CONNECTION_TIMEOUT_MS;
+import static com.linkedin.kmf.common.Utils.ZK_SESSION_TIMEOUT_MS;
 import com.linkedin.kmf.common.DefaultTopicSchema;
 import com.linkedin.kmf.common.Utils;
 import com.linkedin.kmf.consumer.BaseConsumerRecord;
@@ -17,11 +19,17 @@ import com.linkedin.kmf.consumer.NewConsumer;
 import com.linkedin.kmf.consumer.OldConsumer;
 import com.linkedin.kmf.services.configs.ConsumeServiceConfig;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.avro.generic.GenericRecord;
@@ -40,10 +48,16 @@ import org.apache.kafka.common.metrics.stats.Percentile;
 import org.apache.kafka.common.metrics.stats.Percentiles;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Total;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import kafka.cluster.Broker;
+import kafka.cluster.EndPoint;
+import kafka.utils.ZkUtils;
+import scala.Tuple2;
 
 public class ConsumeService implements Service {
   private static final Logger LOG = LoggerFactory.getLogger(ConsumeService.class);
@@ -60,26 +74,35 @@ public class ConsumeService implements Service {
   private final int _latencyPercentileGranularityMs;
   private final AtomicBoolean _running;
   private final int _latencySlaMs;
+  private final String _zkConnect;
+  private final String _topic;
+  private final int _intervalPartitionLeaderExecutor;
+  private final ScheduledExecutorService _handlePartitionLeaderInfoExecutor;
+  private final Map<Integer, Broker> _partitionToBroker;
 
   public ConsumeService(Map<String, Object> props, String name) throws Exception {
     _name = name;
     Map consumerPropsOverride = props.containsKey(ConsumeServiceConfig.CONSUMER_PROPS_CONFIG)
       ? (Map) props.get(ConsumeServiceConfig.CONSUMER_PROPS_CONFIG) : new HashMap<>();
     ConsumeServiceConfig config = new ConsumeServiceConfig(props);
-    String topic = config.getString(ConsumeServiceConfig.TOPIC_CONFIG);
-    String zkConnect = config.getString(ConsumeServiceConfig.ZOOKEEPER_CONNECT_CONFIG);
+    _topic = config.getString(ConsumeServiceConfig.TOPIC_CONFIG);
+    _zkConnect = config.getString(ConsumeServiceConfig.ZOOKEEPER_CONNECT_CONFIG);
     String brokerList = config.getString(ConsumeServiceConfig.BOOTSTRAP_SERVERS_CONFIG);
     String consumerClassName = config.getString(ConsumeServiceConfig.CONSUMER_CLASS_CONFIG);
     _latencySlaMs = config.getInt(ConsumeServiceConfig.LATENCY_SLA_MS_CONFIG);
     _latencyPercentileMaxMs = config.getInt(ConsumeServiceConfig.LATENCY_PERCENTILE_MAX_MS_CONFIG);
     _latencyPercentileGranularityMs = config.getInt(ConsumeServiceConfig.LATENCY_PERCENTILE_GRANULARITY_MS_CONFIG);
+    _intervalPartitionLeaderExecutor = config.getInt(ConsumeServiceConfig.PARTITION_TO_LEADER_REFRESH_INTERVAL_MS_CONFIG);
     _running = new AtomicBoolean(false);
+    _partitionToBroker = new ConcurrentHashMap<>();
 
     for (String property: NONOVERRIDABLE_PROPERTIES) {
       if (consumerPropsOverride.containsKey(property)) {
         throw new ConfigException("Override must not contain " + property + " config.");
       }
     }
+
+    _handlePartitionLeaderInfoExecutor = Executors.newSingleThreadScheduledExecutor(new HandlePartitionLeaderInfoThreadFactory());
 
     Properties consumerProps = new Properties();
 
@@ -102,12 +125,12 @@ public class ConsumeService implements Service {
 
     // Assign config specified for ConsumeService.
     consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    consumerProps.put("zookeeper.connect", zkConnect);
+    consumerProps.put("zookeeper.connect", _zkConnect);
 
     // Assign config specified for consumer. This has the highest priority.
     consumerProps.putAll(consumerPropsOverride);
 
-    _consumer = (KMBaseConsumer) Class.forName(consumerClassName).getConstructor(String.class, Properties.class).newInstance(topic, consumerProps);
+    _consumer = (KMBaseConsumer) Class.forName(consumerClassName).getConstructor(String.class, Properties.class).newInstance(_topic, consumerProps);
 
     _thread = new Thread(new Runnable() {
       @Override
@@ -181,6 +204,14 @@ public class ConsumeService implements Service {
         nextIndexes.put(partition, index + 1);
         _sensors._recordsLost.record(index - nextIndex);
       }
+
+      Broker broker = _partitionToBroker.get(partition);
+      Collection<Tuple2<SecurityProtocol, EndPoint>> endPoints = scala.collection.JavaConversions.asJavaCollection(broker.endPoints());
+      for (Tuple2<SecurityProtocol, EndPoint> tuple : endPoints) {
+        String brokerUrl = tuple._2.host() + ":" + tuple._2.port();
+        Sensor delay = _sensors.getOrCreateBrokerSensor(brokerUrl);
+        delay.record(currMs - prevMs);
+      }
     }
   }
 
@@ -188,6 +219,7 @@ public class ConsumeService implements Service {
   public synchronized void start() {
     if (_running.compareAndSet(false, true)) {
       _thread.start();
+      _handlePartitionLeaderInfoExecutor.scheduleWithFixedDelay(new PartitionLeaderInfoHandler(), 1000, _intervalPartitionLeaderExecutor, TimeUnit.MILLISECONDS);
       LOG.info("{}/ConsumeService started", _name);
     }
   }
@@ -196,6 +228,7 @@ public class ConsumeService implements Service {
   public synchronized void stop() {
     if (_running.compareAndSet(true, false)) {
       try {
+        _handlePartitionLeaderInfoExecutor.shutdown();
         _consumer.close();
       } catch (Exception e) {
         LOG.warn(_name + "/ConsumeService while trying to close consumer.", e);
@@ -214,18 +247,46 @@ public class ConsumeService implements Service {
     return _running.get() && _thread.isAlive();
   }
 
+  /**
+   * This should be periodically run to check for partition leadership assignments.
+   */
+  private class PartitionLeaderInfoHandler implements Runnable {
+
+    @Override
+    public void run() {
+      ZkUtils zkUtils = ZkUtils.apply(_zkConnect, ZK_SESSION_TIMEOUT_MS, ZK_CONNECTION_TIMEOUT_MS, JaasUtils.isZkSecurityEnabled());
+      scala.collection.mutable.ArrayBuffer<String> topicList = new scala.collection.mutable.ArrayBuffer<>();
+      topicList.$plus$eq(_topic);
+      scala.collection.Map<Object, scala.collection.Seq<Object>> partitionAssignments =
+          zkUtils.getPartitionAssignmentForTopics(topicList).apply(_topic);
+      scala.collection.Iterator<scala.Tuple2<Object, scala.collection.Seq<Object>>> it = partitionAssignments.iterator();
+      while (it.hasNext()) {
+        scala.Tuple2<Object, scala.collection.Seq<Object>> scalaTuple = it.next();
+        Integer partition = (Integer) scalaTuple._1();
+        scala.Option<Object> leaderOption = zkUtils.getLeaderForPartition(_topic, partition);
+        Broker broker = zkUtils.getBrokerInfo((Integer) leaderOption.get()).get();
+        _partitionToBroker.put(partition, broker);
+      }
+    }
+  }
+
   private class ConsumeMetrics {
     public final Metrics metrics;
     private final Sensor _bytesConsumed;
     private final Sensor _consumeError;
+    private final ConcurrentMap<String, Sensor> _delayPerBroker;
     private final Sensor _recordsConsumed;
     private final Sensor _recordsDuplicated;
     private final Sensor _recordsLost;
     private final Sensor _recordsDelay;
     private final Sensor _recordsDelayed;
+    private final Map<String, String> _tags;
 
     public ConsumeMetrics(final Metrics metrics, final Map<String, String> tags) {
       this.metrics = metrics;
+      this._tags = tags;
+      _delayPerBroker = new ConcurrentHashMap<>();
+
       _bytesConsumed = metrics.sensor("bytes-consumed");
       _bytesConsumed.add(new MetricName("bytes-consumed-rate", METRIC_GROUP_NAME, "The average number of bytes per second that are consumed", tags), new Rate());
 
@@ -282,6 +343,23 @@ public class ConsumeService implements Service {
       );
     }
 
+    Sensor getOrCreateBrokerSensor(String endpoint) {
+      if (_delayPerBroker.containsKey(endpoint)) {
+        return _delayPerBroker.get(endpoint);
+      }
+      Sensor delayBrokerSensor = metrics.sensor("delay-broker-" + endpoint);
+      delayBrokerSensor.add(new MetricName("delay-ms-avg-broker-" + endpoint, METRIC_GROUP_NAME,
+          "The average latency of records from producer to consumer for broker", _tags),  new Avg());
+      _delayPerBroker.put(endpoint, delayBrokerSensor);
+      return delayBrokerSensor;
+    }
+  }
+
+  private class HandlePartitionLeaderInfoThreadFactory implements ThreadFactory {
+    @Override
+    public Thread newThread(Runnable r) {
+      return new Thread(r, _name + "-consume-service-partition-leader-handler");
+    }
   }
 
 }

--- a/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
+++ b/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
@@ -139,9 +139,6 @@ public class SignalFxMetricsReporterService implements Service {
         if (parts.length < 2 || !parts[1].contains("cluster-monitor")) {
           continue;
         }
-        if (metric.contains("broker")) {
-          LOG.info("Metric : {}", attributeValue.toString());
-        }
         setMetricValue(attributeValue);
       }
     }

--- a/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
+++ b/src/main/java/com/linkedin/kmf/services/SignalFxMetricsReporterService.java
@@ -4,13 +4,7 @@
 package com.linkedin.kmf.services;
 
 import static com.linkedin.kmf.common.Utils.getMBeanAttributeValues;
-import com.codahale.metrics.MetricRegistry;
-import com.linkedin.kmf.common.MbeanAttributeValue;
-import com.linkedin.kmf.services.configs.SignalFxMetricsReporterServiceConfig;
-import com.signalfx.codahale.metrics.SettableDoubleGauge;
-import com.signalfx.codahale.reporter.MetricMetadata;
-import com.signalfx.codahale.reporter.SignalFxReporter;
-import com.signalfx.endpoint.SignalFxEndpoint;
+
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
@@ -18,9 +12,18 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.MetricRegistry;
+import com.linkedin.kmf.common.MbeanAttributeValue;
+import com.linkedin.kmf.services.configs.SignalFxMetricsReporterServiceConfig;
+import com.signalfx.codahale.metrics.SettableDoubleGauge;
+import com.signalfx.codahale.reporter.MetricMetadata;
+import com.signalfx.codahale.reporter.SignalFxReporter;
+import com.signalfx.endpoint.SignalFxEndpoint;
 
 public class SignalFxMetricsReporterService implements Service {
   private static final Logger LOG = LoggerFactory.getLogger(SignalFxMetricsReporterService.class);

--- a/src/main/java/com/linkedin/kmf/services/configs/ConsumeServiceConfig.java
+++ b/src/main/java/com/linkedin/kmf/services/configs/ConsumeServiceConfig.java
@@ -46,6 +46,9 @@ public class ConsumeServiceConfig extends AbstractConfig {
   public static final String LATENCY_SLA_MS_DOC = "The maximum latency of message delivery under SLA. Consume availability is measured "
                                                   + "as the fraction of messages that are either lost or whose delivery latency exceeds this value";
 
+  public static final String PARTITION_TO_LEADER_REFRESH_INTERVAL_MS_CONFIG = "consume.partitionToLeader.refresh.interval.ms";
+  public static final String PARTITION_TO_LEADER_REFRESH_INTERVAL_MS_DOC = "The interval in ms to find partition-leader mapping";
+
   static {
     CONFIG = new ConfigDef().define(ZOOKEEPER_CONNECT_CONFIG,
                                     ConfigDef.Type.STRING,
@@ -78,7 +81,12 @@ public class ConsumeServiceConfig extends AbstractConfig {
                                     ConfigDef.Type.INT,
                                     20000,
                                     ConfigDef.Importance.MEDIUM,
-                                    LATENCY_SLA_MS_DOC);
+                                    LATENCY_SLA_MS_DOC)
+                            .define(PARTITION_TO_LEADER_REFRESH_INTERVAL_MS_CONFIG,
+                                ConfigDef.Type.INT,
+                                10000,
+                                ConfigDef.Importance.MEDIUM,
+                                PARTITION_TO_LEADER_REFRESH_INTERVAL_MS_DOC);
 
   }
 


### PR DESCRIPTION
1 - Add avg-delay metric per broker to determine latency for each broker from producer and consumer
2 - Each partition has one server which acts as the "leader" and zero or more servers which act as "followers". The leader handles all read and write requests for the partition while the followers passively replicate the leader
3 - PartitionLeaderInfoHandler runs periodically(every 10s) to update partition to broker configuration.